### PR TITLE
add support for external structs, arrays

### DIFF
--- a/examples/c/01_struct/src/main.c
+++ b/examples/c/01_struct/src/main.c
@@ -5,6 +5,19 @@ ECS_STRUCT(Position, {
     int32_t y;
 });
 
+struct Extern_struct
+{
+    int32_t x;
+    int32_t y;
+};
+
+typedef struct Extern_struct Extern_struct;
+
+ECS_STRUCT_EXTERN(Extern_struct, {
+    int32_t a;
+    int32_t b;
+});
+
 int main(int argc, char *argv[]) {
     ecs_world_t *world = ecs_init_w_args(argc, argv);
 
@@ -15,11 +28,19 @@ int main(int argc, char *argv[]) {
      * Position type as a component */
     ECS_META(world, Position);
 
+    ECS_META(world, Extern_struct);
+
     /* Create an instance of the Position type */
     Position p = {10, 20};
 
     /* Pretty print the value */
     char *str = ecs_ptr_to_str(world, ecs_entity(Position), &p);
+    printf("%s\n", str);
+    free(str);
+
+    struct Extern_struct e = { .x = 1, .y = 2};
+
+    str = ecs_ptr_to_str(world, ecs_entity(Extern_struct), &e);
     printf("%s\n", str);
     free(str);
 

--- a/include/flecs_meta.h
+++ b/include/flecs_meta.h
@@ -19,6 +19,10 @@ typedef struct name __VA_ARGS__ name;\
 ECS_UNUSED \
 static EcsMetaType __##name##__ = {EcsStructType, sizeof(name), ECS_ALIGNOF(name), descriptor};\
 
+#define ECS_STRUCT_EXTERN_IMPL(name, descriptor)\
+ECS_UNUSED \
+static EcsMetaType __##name##__ = {EcsStructType, sizeof(name), ECS_ALIGNOF(name), descriptor};\
+
 #define ECS_ENUM_IMPL(name, descriptor, ...)\
 typedef enum name __VA_ARGS__ name;\
 ECS_UNUSED \
@@ -35,6 +39,10 @@ static EcsMetaType __##name##__ = {EcsBitmaskType, sizeof(name), ECS_ALIGNOF(nam
 
 #define ECS_ARRAY(name, T, length)\
 typedef T name[length];\
+ECS_UNUSED \
+static EcsMetaType __##name##__ = {EcsArrayType, sizeof(T) * length, ECS_ALIGNOF(T), "(" #T "," #length ")"};
+
+#define ECS_ARRAY_EXTERN(name, T, length)\
 ECS_UNUSED \
 static EcsMetaType __##name##__ = {EcsArrayType, sizeof(T) * length, ECS_ALIGNOF(T), "(" #T "," #length ")"};
 
@@ -105,6 +113,10 @@ public:\
 // Define a struct
 #define ECS_STRUCT(name, ...)\
     ECS_STRUCT_IMPL(name, #__VA_ARGS__, __VA_ARGS__)
+
+// Define an external struct
+#define ECS_STRUCT_EXTERN(name, ...)\
+    ECS_STRUCT_EXTERN_IMPL(name, #__VA_ARGS__)
 
 // Define an enumeration
 #define ECS_ENUM(name, ...)\

--- a/test/serialize/src/Array.c
+++ b/test/serialize/src/Array.c
@@ -14,6 +14,8 @@ ECS_STRUCT(Struct_w_array, {
     int32_t ints[2];
 });
 
+typedef int extern_array[2];
+
 ECS_ARRAY(ArrayBool, bool, 2);
 ECS_ARRAY(ArrayInt, int32_t, 2);
 ECS_ARRAY(ArrayString, ecs_string_t, 2);
@@ -24,6 +26,7 @@ ECS_ARRAY(ArrayArrayInt, ArrayInt, 2);
 ECS_ARRAY(ArrayArrayString, ArrayString, 2);
 ECS_ARRAY(ArrayArrayPoint, ArrayPoint, 2);
 ECS_ARRAY(ArrayArrayLine, ArrayLine, 2);
+ECS_ARRAY_EXTERN(extern_array, int32_t, 2);
 
 void Array_array_bool() {
     ecs_world_t *world = ecs_init();
@@ -48,6 +51,7 @@ void Array_array_int() {
     ECS_IMPORT(world, FlecsMeta);
 
     ECS_META(world, ArrayInt);
+    ECS_META(world, extern_array);
 
     {
     int32_t value[] = {10, -20};
@@ -55,6 +59,14 @@ void Array_array_int() {
     test_str(str, "[10, -20]");
     ecs_os_free(str);
     }
+
+    {
+    extern_array value = {10, -20};
+    char *str = ecs_ptr_to_str(world, ecs_entity(extern_array), value);
+    test_str(str, "[10, -20]");
+    ecs_os_free(str);
+    }
+
 
     ecs_fini(world);
 }


### PR DESCRIPTION
I've added a test for arrays but the struct test is failing which i haven't touched yet: `flecs-meta/test/deserailizer/src/Struct.c:127: undefined reference to 'test_uint'`

This appears to work with the caveat that external structs need an `ECS_PRIVATE` annotation to force flecs-meta to not ignore the struct's extra alignment, external arrays might have a similar issue but I haven't had the chance to check this yet.

This should be considered for merging after #8