### PR TITLE
External type support at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a reflection library for C/C++ that uses Flecs to store the meta definit
 
 The library supports:
  - Lots of primitive types
+ - External types
  - Enumerations
  - Bitmasks
  - Structs
@@ -82,6 +83,26 @@ Output:
 
 ```
 {name = "Foobar", value = 10, is_active = true}
+```
+
+### External types
+
+External types can be defined like any other type
+
+```c
+#include <library.h>
+
+ECS_STRUCT_EXTERN(vec2,
+{
+    float x;
+    float y;
+});
+
+ECS_STRUCT(Point
+{
+    vec2 Position;
+    bool draw;
+});
 ```
 
 ### Enumerations

--- a/include/flecs_meta.h
+++ b/include/flecs_meta.h
@@ -19,6 +19,10 @@ typedef struct name __VA_ARGS__ name;\
 ECS_UNUSED \
 static EcsMetaType __##name##__ = {EcsStructType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL}\
 
+#define ECS_STRUCT_EXTERN_IMPL(name, descriptor)\
+ECS_UNUSED \
+static EcsMetaType __##name##__ = {EcsStructType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL}
+
 #define ECS_ENUM_IMPL(name, descriptor, ...)\
 typedef enum name __VA_ARGS__ name;\
 ECS_UNUSED \
@@ -37,6 +41,10 @@ static EcsMetaType __##name##__ = {EcsBitmaskType, sizeof(name), ECS_ALIGNOF(nam
 typedef T name[length];\
 ECS_UNUSED \
 static EcsMetaType __##name##__ = {EcsArrayType, sizeof(T) * length, ECS_ALIGNOF(T), "(" #T "," #length ")", NULL}
+
+#define ECS_ARRAY_EXTERN(name, T, length)\
+ECS_UNUSED \
+static EcsMetaType __##name##__ = {EcsArrayType, sizeof(T) * length, ECS_ALIGNOF(name), "(" #T "," #length ")", NULL}
 
 #define ECS_VECTOR(name, T)\
 typedef ecs_vector_t *name;\
@@ -105,6 +113,10 @@ public:\
 // Define a struct
 #define ECS_STRUCT(name, ...)\
     ECS_STRUCT_IMPL(name, #__VA_ARGS__, __VA_ARGS__)
+
+// Define an external struct
+#define ECS_STRUCT_EXTERN(name, ...)\
+    ECS_STRUCT_EXTERN_IMPL(name, #__VA_ARGS__)
 
 // Define an enumeration
 #define ECS_ENUM(name, ...)\


### PR DESCRIPTION
In conjunction with `ECS_ALIAS()` it would allow typedefs + meta aliases of external types.

```c

ECS_STRUCT_EXTERN(vec3,
{
    float x;
    float y;
    float z;
});

ECS_ALIAS(vec3, Position); //meta alias and typedef

ECS_STRUCT(example,
{
    Position p;
    bool b;
});

//everything is registered with the same macro
ECS_META(world, vec3);
ECS_META(world, Position);
ECS_META(world, example);