### PR TITLE
update macros: __##name##__ -> FLECS__D##name

### DIFF
--- a/include/flecs_meta.h
+++ b/include/flecs_meta.h
@@ -121,7 +121,7 @@ public:\
 #define ECS_ALIAS(type, name)\
     typedef type name;\
     ECS_UNUSED \
-    static EcsMetaType ecs_meta(name) = {0, sizeof(name), ECS_ALIGNOF(name), NULL, &FLECS__D##type};\
+    static EcsMetaType ecs_meta(name) = {0, sizeof(name), ECS_ALIGNOF(name), NULL, &ecs_meta(type)};\
 
 #endif
 
@@ -549,7 +549,7 @@ void ecs_new_meta(
 
 #define ECS_META(world, T)\
     ECS_COMPONENT(world, T);\
-    ecs_new_meta(world, ecs_entity(T), &FLECS__D##T);
+    ecs_new_meta(world, ecs_entity(T), &ecs_meta(T));
 
 /** Define a meta component, store in variable outside of the current scope.
 * Use this macro in a header when defining a component identifier globally.
@@ -557,7 +557,7 @@ void ecs_new_meta(
 */
 #define ECS_META_DEFINE(world, T)\
     ECS_COMPONENT_DEFINE(world, T);\
-    ecs_new_meta(world, ecs_entity(T), &FLECS__D##T);
+    ecs_new_meta(world, ecs_entity(T), &ecs_meta(T));
 
 #ifdef __cplusplus
 }

--- a/include/flecs_meta.h
+++ b/include/flecs_meta.h
@@ -9,25 +9,28 @@
 //// Utility macro's (do not use in code!)
 ////////////////////////////////////////////////////////////////////////////////
 
+/** Translate C type to metatype. */
+#define ecs_meta(name) FLECS__D##name
+
 #define ECS_ENUM_BOOTSTRAP(name, ...)\
 typedef enum name __VA_ARGS__ name;\
 ECS_UNUSED \
-static const char * __##name##__ = #__VA_ARGS__;
+static const char * ecs_meta(name) = #__VA_ARGS__;
 
 #define ECS_STRUCT_IMPL(name, descriptor, ...)\
 typedef struct name __VA_ARGS__ name;\
 ECS_UNUSED \
-static EcsMetaType __##name##__ = {EcsStructType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL};
+static EcsMetaType ecs_meta(name) = {EcsStructType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL};
 
 #define ECS_ENUM_IMPL(name, descriptor, ...)\
 typedef enum name __VA_ARGS__ name;\
 ECS_UNUSED \
-static EcsMetaType __##name##__ = {EcsEnumType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL};
+static EcsMetaType ecs_meta(name) = {EcsEnumType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL};
 
 #define ECS_BITMASK_IMPL(name, descriptor, ...)\
 typedef enum name __VA_ARGS__ name;\
 ECS_UNUSED \
-static EcsMetaType __##name##__ = {EcsBitmaskType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL};
+static EcsMetaType ecs_meta(name) = {EcsBitmaskType, sizeof(name), ECS_ALIGNOF(name), descriptor, NULL};
 
 #define ECS_STRUCT_C(T, ...) ECS_STRUCT_IMPL(T, #__VA_ARGS__, __VA_ARGS__)
 #define ECS_ENUM_C(T, ...) ECS_ENUM_IMPL(T, #__VA_ARGS__, __VA_ARGS__)
@@ -36,17 +39,17 @@ static EcsMetaType __##name##__ = {EcsBitmaskType, sizeof(name), ECS_ALIGNOF(nam
 #define ECS_ARRAY(name, T, length)\
 typedef T name[length];\
 ECS_UNUSED \
-static EcsMetaType __##name##__ = {EcsArrayType, sizeof(T) * length, ECS_ALIGNOF(T), "(" #T "," #length ")", NULL}
+static EcsMetaType ecs_meta(name) = {EcsArrayType, sizeof(T) * length, ECS_ALIGNOF(T), "(" #T "," #length ")", NULL}
 
 #define ECS_VECTOR(name, T)\
 typedef ecs_vector_t *name;\
 ECS_UNUSED \
-static EcsMetaType __##name##__ = {EcsVectorType, sizeof(ecs_vector_t*), ECS_ALIGNOF(ecs_vector_t*), "(" #T ")", NULL}
+static EcsMetaType ecs_meta(name) = {EcsVectorType, sizeof(ecs_vector_t*), ECS_ALIGNOF(ecs_vector_t*), "(" #T ")", NULL}
 
 #define ECS_MAP(name, K, T)\
 typedef ecs_map_t *name;\
 ECS_UNUSED \
-static EcsMetaType __##name##__ = {EcsMapType, sizeof(ecs_map_t*), ECS_ALIGNOF(ecs_map_t*), "(" #K "," #T ")", NULL}
+static EcsMetaType ecs_meta(name) = {EcsMapType, sizeof(ecs_map_t*), ECS_ALIGNOF(ecs_map_t*), "(" #K "," #T ")", NULL}
 
 #ifdef __cplusplus
 
@@ -118,7 +121,7 @@ public:\
 #define ECS_ALIAS(type, name)\
     typedef type name;\
     ECS_UNUSED \
-    static EcsMetaType __##name##__ = {0, sizeof(name), ECS_ALIGNOF(name), NULL, &__##type##__};\
+    static EcsMetaType ecs_meta(name) = {0, sizeof(name), ECS_ALIGNOF(name), NULL, &FLECS__D##type};\
 
 #endif
 
@@ -546,7 +549,7 @@ void ecs_new_meta(
 
 #define ECS_META(world, T)\
     ECS_COMPONENT(world, T);\
-    ecs_new_meta(world, ecs_entity(T), &__##T##__);
+    ecs_new_meta(world, ecs_entity(T), &FLECS__D##T);
 
 /** Define a meta component, store in variable outside of the current scope.
 * Use this macro in a header when defining a component identifier globally.
@@ -554,7 +557,7 @@ void ecs_new_meta(
 */
 #define ECS_META_DEFINE(world, T)\
     ECS_COMPONENT_DEFINE(world, T);\
-    ecs_new_meta(world, ecs_entity(T), &__##T##__);
+    ecs_new_meta(world, ecs_entity(T), &FLECS__D##T);
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -393,7 +393,7 @@ void ecs_new_meta(
 
 /* Utility macro to insert meta data for type with meta descriptor */
 #define ECS_COMPONENT_TYPE(world, type)\
-    ecs_set_ptr(world, ecs_id(type), EcsMetaType, &__##type##__)
+    ecs_set_ptr(world, ecs_id(type), EcsMetaType, &ecs_meta(type))
 
 /* Utility macro to insert metadata for primitive type */
 #define ECS_COMPONENT_PRIMITIVE(world, type, kind)\
@@ -507,16 +507,16 @@ void FlecsMetaImport(
     ecs_set_scope(world, old_scope);
 
     /* -- Initialize builtin meta components -- */
-    
+
     ecs_set_ptr(world, ecs_set_name(world, 0, "ecs_primitive_kind_t"),
-        EcsMetaType, &__ecs_primitive_kind_t__);
+        EcsMetaType, &ecs_meta(ecs_primitive_kind_t));
 
     ecs_set(world, ecs_set_name(world, 0, "ecs_type_kind_t"),
         EcsMetaType, {
             EcsEnumType,
             sizeof(ecs_type_kind_t),
             ECS_ALIGNOF(ecs_type_kind_t),
-            __ecs_type_kind_t__,
+            ecs_meta(ecs_type_kind_t),
             NULL
         });
 


### PR DESCRIPTION
Mostly a change to move away from using leading double underscores, which is reserved by the standard.