### PR TITLE
ecs_primitive_kind_t: start enums at 1

### DIFF
--- a/flecs_meta.h
+++ b/flecs_meta.h
@@ -225,7 +225,7 @@ ECS_STRUCT( EcsMetaType, {
 })
 
 ECS_ENUM( ecs_primitive_kind_t, {
-    EcsBool,
+    EcsBool = 1,
     EcsChar,
     EcsByte,
     EcsU8,

--- a/include/flecs_meta.h
+++ b/include/flecs_meta.h
@@ -185,7 +185,7 @@ ECS_STRUCT( EcsMetaType, {
 })
 
 ECS_ENUM( ecs_primitive_kind_t, {
-    EcsBool,
+    EcsBool = 1,
     EcsChar,
     EcsByte,
     EcsU8,


### PR DESCRIPTION
This allows an `is_primitive()` function to return zero when a component is not a primitive without conflicting with the value of `EcsBool` and vice versa.